### PR TITLE
Apply more idiomatic Rust to main app logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ This project is licensed under the [MIT license](LICENSE). Contributions will be
 
 This is a changelog describing the most important changes per release.
 
+### Version 0.2.1 — 21.02.2023
+
+- Small refactor for more idiomatic Rust
+- Fix bug in which `--words` input was overridden
+
 ### Version 0.2.0 — 30.09.2022
 
 - Refactor code for better readability

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,9 +49,16 @@ fn main() -> ExitCode {
 
     if atty::isnt(Stream::Stdin) {
         input = utils::read_from_stdin();
-        if input.chars().count() > 0 {
+        // Needs a minumum of 3 words to produce output
+        if input.split_whitespace().count() >= 3 {
             println!("{}", custom::run(&input, words));
             exit(0);
+        } else {
+            eprintln!(
+                "Error: not enough words received from stdin, needs a minimum of \
+              three whitespace-seperated words"
+            );
+            exit(1);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 extern crate core;
 
-use std::process::{exit, ExitCode};
 use atty::Stream;
 use clap::{ArgEnum, Parser};
+use std::process::{exit, ExitCode};
 
+mod custom;
 mod liber_primus;
 mod lorem_ipsum;
-mod custom;
 mod utils;
 
 #[derive(Parser)]
@@ -37,40 +37,30 @@ enum TextSource {
 fn main() -> ExitCode {
     let args = Args::parse();
 
-    let file = args.file.unwrap_or("".to_string());
+    let words = args.words.unwrap_or(5);
     let source = args.text_source;
     let input;
-    let words;
 
-    if file != "" {
-        words = 5;
+    if let Some(file) = args.file {
         input = utils::read_from_file(&file);
-        println!("{}", custom::run(&*input, words));
+        println!("{}", custom::run(&input, words));
         exit(0);
     }
 
     if atty::isnt(Stream::Stdin) {
         input = utils::read_from_stdin();
         if input.chars().count() > 0 {
-            words = 5;
-            println!("{}", custom::run(&*input, words));
+            println!("{}", custom::run(&input, words));
             exit(0);
         }
     }
 
-    if source == TextSource::LoremIpsum {
-        words = 5;
-        println!("{}", lorem_ipsum::run(words));
-        exit(0);
+    match source {
+        TextSource::LoremIpsum => println!("{}", lorem_ipsum::run(words)),
+        TextSource::LiberPrimus => println!("{}", liber_primus::run(words)),
     }
 
-    if source == TextSource::LiberPrimus {
-        words = 0;
-        println!("{}", liber_primus::run(words));
-        exit(0);
-    }
-
-    panic!("Invalid source");
+    exit(0);
 }
 
 #[test]


### PR DESCRIPTION
Hi there! I found this tool via Cargo as I was looking for a quick and easy way to generate some lorem ipsum and I noticed some things weren't quite working as expected. I went ahead and fixed it up so I could use the tool locally and I figured I should share my changes with you should you want to incorporate them.

Here's a summary of my changes:

- Make use of the `Option` type to set default arg values
  - This fixes the word count getting overridden to 5 no matter what number is passed
- Replace chain of if statements with match block for command switching
  - By using a match statement we now will receive an error at compile-time warning us of non-exhaustive matches
- Remove unnecessary `panic!`
  - Clap would panic before we reach this point for the case this statement intended to cover
- Ensure stdin exits if too little input is received (< 3 words)