### PR TITLE
Implements inserting of new lines by a certain count given as option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ OPTIONS:
     -V, --version                      Print version information
     -w, --words <WORDS>                Count of words to generate. Default is 5 if text source is
                                        not liber-primus
+    -l, --words-per-line               Count of words after a new line is inserted. By default deactivated
+                                       Zero is the same as deactivated
+                                       No new line will come after the last word
 
 ```
 
@@ -73,8 +76,20 @@ This will generate a string of 10 words from stdin
 
 This will generate a string of 10 words using the lorem ipsum example filler text beginning with “Lorem ipsum dolor sit amet”
     
-    $ lipsum-cli lorem-ipsum --words 10
+    $ lipsum-cli --text-source lorem-ipsum --words 10
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do.
+
+This will generate a string of 20 words with a new line after 4th word.
+
+    $ lipsum-cli --words 30 --words-per-line 4
+    Multavit. -- Si sine
+    causa, nollem me ab
+    eo dissentiunt, sed certe
+    non probes, eum quem
+    ego arbitror unum vidisse
+    verum maximisque erroribus animos
+    hominum liberavisse et omnia
+    tradidisse, quae.
 
 ## CONTRIBUTING
     
@@ -95,7 +110,6 @@ This project is licensed under the [MIT license](LICENSE). Contributions will be
 ## Release History
 
 This is a changelog describing the most important changes per release.
-
 
 ### Version 0.2.2 — 24.02.2023
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,12 @@ extern crate core;
 
 use atty::Stream;
 use clap::{Parser, ValueEnum};
-use std::process::{exit};
+use std::process::exit;
 
 mod custom;
 mod liber_primus;
 mod lorem_ipsum;
+mod new_lines;
 mod utils;
 
 #[derive(Parser)]
@@ -23,9 +24,14 @@ struct Args {
     #[arg(short, long)]
     file: Option<String>,
 
-    /// Count of words to generate. Default is 5 if text source is not liber-primus.
+    /// Count of words to generate. Default is 10 if text source is not liber-primus.
     #[arg(short, long)]
     words: Option<usize>,
+
+    /// Count of words after a new line is inserted. By default deactivated.
+    /// Zero is the same as deactivated
+    #[arg(short = 'l', long)]
+    words_per_line: Option<usize>,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -34,16 +40,17 @@ enum TextSource {
     LoremIpsum,
 }
 
-fn main()  {
+fn main() {
     let args = Args::parse();
 
     let words = args.words.unwrap_or(5);
     let source = args.text_source;
+    let words_per_line = args.words_per_line;
     let input;
 
     if let Some(file) = args.file {
         input = utils::read_from_file(&file);
-        println!("{}", custom::run(&input, words));
+        print_output(custom::run(&input, words), words_per_line);
         exit(0);
     }
 
@@ -51,7 +58,7 @@ fn main()  {
         input = utils::read_from_stdin();
         // Needs a minumum of 3 words to produce output
         if input.split_whitespace().count() >= 3 {
-            println!("{}", custom::run(&input, words));
+            print_output(custom::run(&input, words), words_per_line);
             exit(0);
         } else {
             eprintln!(
@@ -63,11 +70,20 @@ fn main()  {
     }
 
     match source {
-        TextSource::LoremIpsum => println!("{}", lorem_ipsum::run(words)),
-        TextSource::LiberPrimus => println!("{}", liber_primus::run(words)),
+        TextSource::LoremIpsum => print_output(lorem_ipsum::run(words), words_per_line),
+        TextSource::LiberPrimus => print_output(liber_primus::run(words), words_per_line),
     }
 
     exit(0);
+}
+
+fn print_output(output: String, may_words_per_line: Option<usize>) {
+    if let Some(words_per_line) = may_words_per_line {
+        let with_new_lines = new_lines::ensure_new_lines_by(output, words_per_line);
+        println!("{}", with_new_lines);
+    } else {
+        println!("{}", output);
+    }
 }
 
 #[test]

--- a/src/new_lines.rs
+++ b/src/new_lines.rs
@@ -1,0 +1,51 @@
+/// NOTE: New lines before the insertion are removed
+pub fn ensure_new_lines_by(input: String, words_per_line: usize) -> String {
+    if input.len() < words_per_line {
+        input
+    } else {
+        const NEW_LINE: char = '\n';
+
+        let mut output = String::with_capacity(input.len());
+        let mut counter: usize = 0;
+
+        for next_word in input.replace(NEW_LINE, "").split_whitespace() {
+            output.push_str(next_word);
+            counter += 1;
+            if counter == words_per_line {
+                counter = 0;
+                output.push('\n');
+            } else {
+                output.push(' ');
+            }
+        }
+
+        // Makes sure the no new line or space comes after last word
+        let take_by = output.len() - 1;
+        output.chars().take(take_by).collect()
+    }
+}
+
+#[cfg(test)]
+mod testing {
+    use super::*;
+
+    #[test]
+    fn should_have_new_lines() {
+        assert_case(
+            "Consuetudinum instituendarum voluntates fieri propter voluptatem; quod vero securi percussit filium, privavisse se etiam videtur multis voluptatibus, cum ipsi naturae.",
+            "Consuetudinum instituendarum voluntates fieri propter\nvoluptatem; quod vero securi percussit\nfilium, privavisse se etiam videtur\nmultis voluptatibus, cum ipsi naturae.",
+            5
+        );
+        assert_case("Not to be changed", "Not to be changed", 0);
+        assert_case("Hello world, out there.", "Hello\nworld,\nout\nthere.", 1);
+        assert_case("Natura postulet non intellegunt, errore maximo, si Epicurum audire voluerint, liberabuntur: istae enim vestrae", 
+            "Natura postulet non\nintellegunt, errore maximo,\nsi Epicurum audire\nvoluerint, liberabuntur: istae\nenim vestrae", 3);
+        // New lines from input should be ignored
+        assert_case("Natura postulet\n non intellegunt\n, errore maximo, si Epicurum audire\n voluerint, liberabuntur\n: istae enim vestrae", 
+            "Natura postulet non\nintellegunt, errore maximo,\nsi Epicurum audire\nvoluerint, liberabuntur: istae\nenim vestrae", 3);
+        fn assert_case(input: &str, expected: &str, lines: usize) {
+            let actual = ensure_new_lines_by(input.to_string(), lines);
+            assert_eq!(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
Added new CLI argument. Is by default deactivated.

Updated usage with new argument.
Provided example with usage of new lines insertion

Implementation resides in own module

Centralized println call via new function in main
to ensure that no path of execution dodges
the line insertion if the option was given.

Bugfix: Previous Example

"lipsum-cli lorem-ipsum --words 10" is not valid
Changed to
"lipsum-cli --text-source lorem-ipsum --words 10"